### PR TITLE
let struct mcontext_t and sigcontex have the same definition

### DIFF
--- a/sysdeps/unix/sysv/linux/loongarch/getcontext.S
+++ b/sysdeps/unix/sysv/linux/loongarch/getcontext.S
@@ -55,7 +55,8 @@ LEAF (__getcontext)
 
 /* rt_sigprocmask (SIG_BLOCK, NULL, &ucp->uc_sigmask, _NSIG8) */
 	li.d	a3, _NSIG8
-	addi.d     a2, a0, UCONTEXT_SIGMASK
+	li.d	a2, UCONTEXT_SIGMASK
+	add.d	a2, a2, a0
 	ori	a1, zero,0
 	li.d	a0, SIG_BLOCK
 

--- a/sysdeps/unix/sysv/linux/loongarch/setcontext.S
+++ b/sysdeps/unix/sysv/linux/loongarch/setcontext.S
@@ -35,7 +35,8 @@ LEAF (__setcontext)
 /* rt_sigprocmask (SIG_SETMASK, &ucp->uc_sigmask, NULL, _NSIG8) */
 	li.d	a3, _NSIG8
 	li.d	a2, 0
-	addi.d  a1, a0, UCONTEXT_SIGMASK
+	li.d	a1, UCONTEXT_SIGMASK
+	add.d	a1, a1, a0
 	li.d	a0, SIG_SETMASK
 
 	li.d	a7, SYS_ify (rt_sigprocmask)

--- a/sysdeps/unix/sysv/linux/loongarch/swapcontext.S
+++ b/sysdeps/unix/sysv/linux/loongarch/swapcontext.S
@@ -58,8 +58,10 @@ LEAF (__swapcontext)
 
 /* rt_sigprocmask (SIG_SETMASK, &ucp->uc_sigmask, &oucp->uc_sigmask, _NSIG8) */
 	li.d	a3, _NSIG8
-	addi.d	a2, a0, UCONTEXT_SIGMASK
-	addi.d  a1, t0, UCONTEXT_SIGMASK
+	li.d	a2, UCONTEXT_SIGMASK
+	add.d	a2, a2, a0
+	li.d	a1, UCONTEXT_SIGMASK
+	add.d	a1, a1, t0
 	li.d	a0, SIG_SETMASK
 
 	li.d	a7, SYS_ify (rt_sigprocmask)

--- a/sysdeps/unix/sysv/linux/loongarch/sys/ucontext.h
+++ b/sysdeps/unix/sysv/linux/loongarch/sys/ucontext.h
@@ -63,9 +63,10 @@ typedef struct mcontext_t {
     unsigned int   __fcsr;
     unsigned int   __vcsr;
     unsigned long long   __fcc;
+    unsigned long long   __scr[4];
     union __loongarch_mc_fp_state    __fpregs[32] __attribute__((__aligned__ (32)));
 
-    unsigned int   __reserved;
+    unsigned char  __reserved[4096] __attribute__((__aligned__(16)));
 } mcontext_t;
 
 /* Userlevel context.  */


### PR DESCRIPTION
@oy456xd 

Please review and test.