### PR TITLE
Revert "remove bsd*setjmp.c"

### DIFF
--- a/sysdeps/loongarch/bsd-_setjmp.c
+++ b/sysdeps/loongarch/bsd-_setjmp.c
@@ -1,0 +1,1 @@
+/* _setjmp is implemented in setjmp.S */

--- a/sysdeps/loongarch/bsd-setjmp.c
+++ b/sysdeps/loongarch/bsd-setjmp.c
@@ -1,0 +1,1 @@
+/* setjmp is implemented in setjmp.S */

--- a/sysdeps/loongarch/setjmp.S
+++ b/sysdeps/loongarch/setjmp.S
@@ -19,6 +19,13 @@
 #include <sysdep.h>
 #include <sys/asm.h>
 
+ENTRY (_setjmp)
+  li.w a1,0
+  b __sigsetjmp
+END (_setjmp)
+ENTRY (setjmp)
+  li.w a1,1
+END (setjmp)
 ENTRY (__sigsetjmp)
   REG_S ra, a0, 0*SZREG
   REG_S sp, a0, 1*SZREG
@@ -43,11 +50,13 @@ ENTRY (__sigsetjmp)
   FREG_S $f30, a0, 13*SZREG + 6*SZFREG
   FREG_S $f31, a0, 13*SZREG + 7*SZFREG
 
-#if IS_IN(rtld)
+#if !IS_IN (libc) && IS_IN(rtld)
   li.w v0, 0
   jirl zero,ra,0
 #else
-  b C_SYMBOL_NAME(__sigjmp_save)
+  b __sigjmp_save
 #endif
 END (__sigsetjmp)
+
 hidden_def (__sigsetjmp)
+weak_alias (_setjmp, __GI__setjmp)


### PR DESCRIPTION
This reverts commit b10a65d841205bdc4bb427eb3aabb50a4da97792.

If we don't provide our own setjmp() and _setjmp() implementation, glibc
will use the "default" implementation in setjmp/bsd-_setjmp.c and
setjmp/bsd-setjmp.c.  The comment in them says:

    This implementation in C will not usually work, because the call
    really needs to be a tail-call so __sigsetjmp saves the state of
    the caller, not the state of this `setjmp' frame which then
    immediate unwinds.

So they rely on compiler tail-call optimization.  Unfortunately our
compiler (in loongson/gcc) does not do the optimization.  The generated
code (at -O2 or even -O3) is:

    000000000003f3d8 <setjmp>:
       3f3d8:       02ffc063        addi.d          $sp, $sp, -16(0xff0)
       3f3dc:       02800405        addi.w          $a1, $zero, 1(0x1)
       3f3e0:       29c02061        st.d            $ra, $sp, 8(0x8)
       3f3e4:       57ff47ff        bl              -188(0xfffff44)
                                                    # 3f328 <__sigsetjmp>
       3f3e8:       28c02061        ld.d            $ra, $sp, 8(0x8)
       3f3ec:       02c04063        addi.d          $sp, $sp, 16(0x10)
       3f3f0:       4c000020        jirl            $zero, $ra, 0

It won't work, causing setjmp/longjmp to behave strangely.  Glibc test
named `tst-setjmp` fails (trapped in a dead loop), for example.  And
there are many Glibc tests using setjmp/longjmp.  By reverting b10a65d8
the number of failed tests reduced from 157 to 33.

Signed-off-by: Xi Ruoyao <xry111@mengyan1223.wang>