### PR TITLE
loongarch: align stack in clone

### DIFF
--- a/sysdeps/unix/sysv/linux/loongarch/clone.S
+++ b/sysdeps/unix/sysv/linux/loongarch/clone.S
@@ -31,6 +31,14 @@
 
 ENTRY (__clone)
 
+	/* Align stack to 16 or 8 bytes per the ABI.  */
+#if _LOONGARCH_SIM == _ABILP64
+	addi.d		t0, zero, -16
+#elif _LOONGARCH_SIM == _ABILP32
+	addi.w		t0, zero, -8
+#endif
+	and		a1, a1, t0
+
 	/* Sanity check arguments.  */
 	beqz		a0, L (invalid) /* No NULL function pointers.  */
 	beqz		a1, L (invalid) /* No NULL stack pointers.  */


### PR DESCRIPTION
[Note: it's not needed for 2.33, so the target branch is
loongarch_2_34_dev.  Supporting for misaligned stack in clone is a new
feature in 2.34.]

The ELF ABI document of LoongArch is not completed yet, but by reading
GCC code it seems LoongArch prefers 16-byte aligned stack for LP64 and
8-byte aligned stack for LP32, like MIPS.  Previously if the caller
passed an unaligned stack to clone, the child would misbehave.

Glibc-2.34 has been designed to align the stack in library code, so the
caller won't need to take care of stack alignment anymore calling clone.
See commit 92a7d134.

This commit fixes test failures of "misc/tst-misalign-clone" and
"misc/tst-misalign-clone-internal".