### PR TITLE
loongarch: Declare femode_t for C2X

### DIFF
--- a/sysdeps/loongarch/bits/fenv.h
+++ b/sysdeps/loongarch/bits/fenv.h
@@ -81,7 +81,7 @@ typedef struct
 #define FE_NOMASK_ENV ((const fenv_t *) -257)
 #endif
 
-#if __GLIBC_USE(IEC_60559_BFP_EXT)
+#if __GLIBC_USE (IEC_60559_BFP_EXT_C2X)
 /* Type representing floating-point control modes.  */
 typedef unsigned int femode_t;
 


### PR DESCRIPTION
C2X adds interfaces from TS 18661-1 including femode_t [1], so it should
be unconditionally visible in C2X.  In commit 0175c9e9be5f a new macro
__GLIBC_USE_IEC_60559_BFP_EXT_C2X is added for the TS-18661 declarations
which should be available in C2X.  We should used it instead of
__GLIBC_USE_IEC_60559_BFP_EXT for femode_t.

[1]: http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2095.pdf