### PR TITLE
loongarch: add pthread_stack_min.h

### DIFF
--- a/sysdeps/unix/sysv/linux/loongarch/bits/pthread_stack_min.h
+++ b/sysdeps/unix/sysv/linux/loongarch/bits/pthread_stack_min.h
@@ -1,0 +1,20 @@
+/* Definition of PTHREAD_STACK_MIN.  LoongArch Linux version.
+   Copyright (C) 2021 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library.  If not, see
+   <https://www.gnu.org/licenses/>.  */
+
+/* Minimum size for a thread.  At least two pages with 64k pages.  */
+#define PTHREAD_STACK_MIN	131072


### PR DESCRIPTION
The default value of PTHREAD_STACK_MIN is 16 KB.  LoongArch supports
64-KB pages, so we'll need twice the page size, i. e. 128 KB.