### PR TITLE
add LoongArch assembly implementation for fmax/fmaxf/fmin/fminf

### DIFF
--- a/sysdeps/loongarch/fpu/s_fmax.S
+++ b/sysdeps/loongarch/fpu/s_fmax.S
@@ -1,0 +1,27 @@
+/* Assembly implementation of fmax.
+   Copyright (C) 2021 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library.  If not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <sysdep.h>
+#include <libm-alias-double.h>
+
+LEAF(__fmax)
+	fmax.d	fa0, fa0, fa1
+	jr	ra
+END(__fmax)
+libm_alias_double (__fmax, fmax)

--- a/sysdeps/loongarch/fpu/s_fmaxf.S
+++ b/sysdeps/loongarch/fpu/s_fmaxf.S
@@ -1,0 +1,27 @@
+/* Assembly implementation of fmaxf.
+   Copyright (C) 2021 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library.  If not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <sysdep.h>
+#include <libm-alias-float.h>
+
+LEAF(__fmaxf)
+	fmax.s	fa0, fa0, fa1
+	jr	ra
+END(__fmaxf)
+libm_alias_float (__fmax, fmax)

--- a/sysdeps/loongarch/fpu/s_fmin.S
+++ b/sysdeps/loongarch/fpu/s_fmin.S
@@ -1,0 +1,27 @@
+/* Assembly implementation of fmin.
+   Copyright (C) 2021 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library.  If not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <sysdep.h>
+#include <libm-alias-double.h>
+
+LEAF(__fmin)
+	fmin.d	fa0, fa0, fa1
+	jr	ra
+END(__fmin)
+libm_alias_double (__fmin, fmin)

--- a/sysdeps/loongarch/fpu/s_fminf.S
+++ b/sysdeps/loongarch/fpu/s_fminf.S
@@ -1,0 +1,27 @@
+/* Assembly implementation of fminf.
+   Copyright (C) 2021 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library.  If not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <sysdep.h>
+#include <libm-alias-float.h>
+
+LEAF(__fminf)
+	fmin.s	fa0, fa0, fa1
+	jr	ra
+END(__fminf)
+libm_alias_float (__fmin, fmin)


### PR DESCRIPTION
TS 18661-1 specifies that C fmax/fmaxf/fmin/fminf should match
minNum/maxNum in IEC 60559 (IEEE 754).  Our fmin/fmax instructions also
match IEEE 754 behavior, so we can implement those functions with one
instruction.