### PR TITLE
loongarch: change two comments to match the behavior of the code

### DIFF
--- a/sysdeps/unix/sysv/linux/loongarch/clone.S
+++ b/sysdeps/unix/sysv/linux/loongarch/clone.S
@@ -32,7 +32,7 @@
 
 ENTRY (__clone)
 
-	/* Align stack to 16 or 8 bytes per the ABI.  */
+	/* Align stack to 16 bytes.  */
 	BSTRINS		a1, zero, 3, 0
 
 	/* Sanity check arguments.  */

--- a/sysdeps/unix/sysv/linux/loongarch/clone3.S
+++ b/sysdeps/unix/sysv/linux/loongarch/clone3.S
@@ -66,7 +66,7 @@ L (thread_start3):
 	.cfi_label .Ldummy
 	cfi_undefined (1)
 
-	/* Align stack to 16 or 8 bytes per the ABI.  */
+	/* Align stack to 16 bytes.  */
 	BSTRINS		sp, zero, 3, 0
 
 	/* Set up arguments for the function call.  */


### PR DESCRIPTION
The code aligns the stack to 16-byte unconditionally.  Note that ILP32
ABI is not even drafted yet, so we'd not mention it for now.